### PR TITLE
Fix table sorting for abbreviated numbers

### DIFF
--- a/index.html.html
+++ b/index.html.html
@@ -883,17 +883,35 @@
             rows.sort((a, b) => {
                 let aValue = a.cells[columnIndex].textContent.trim();
                 let bValue = b.cells[columnIndex].textContent.trim();
-                
-                // Remove special characters and parse numbers
-                aValue = aValue.replace(/[%+,MK]/g, '');
-                bValue = bValue.replace(/[%+,MK]/g, '');
-                
-                if (!isNaN(aValue) && !isNaN(bValue)) {
-                    aValue = parseFloat(aValue) || 0;
-                    bValue = parseFloat(bValue) || 0;
+
+                const parseNumeric = (val) => {
+                    if (!val) return NaN;
+                    let multiplier = 1;
+                    val = val.replace(/[, %]/g, '');
+                    if (val.endsWith('M')) {
+                        multiplier = 1_000_000;
+                        val = val.slice(0, -1);
+                    } else if (val.endsWith('K')) {
+                        multiplier = 1_000;
+                        val = val.slice(0, -1);
+                    }
+                    val = val.replace(/\+/g, '');
+                    const num = parseFloat(val);
+                    return isNaN(num) ? NaN : num * multiplier;
+                };
+
+                const aNum = parseNumeric(aValue);
+                const bNum = parseNumeric(bValue);
+
+                if (!isNaN(aNum) && !isNaN(bNum)) {
+                    aValue = aNum;
+                    bValue = bNum;
                 } else if (columnIndex === 2) { // Date column
                     aValue = new Date(aValue) || new Date(0);
                     bValue = new Date(bValue) || new Date(0);
+                } else {
+                    aValue = aValue.toLowerCase();
+                    bValue = bValue.toLowerCase();
                 }
                 
                 if (sortDirection[columnIndex]) {


### PR DESCRIPTION
## Summary
- improve table sorting logic in dashboard to correctly handle values with K/M abbreviations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d5d714b4c83268a87b07e77fc1fe6